### PR TITLE
Fix flaky cache tests

### DIFF
--- a/tests/cache/test_shelve.py
+++ b/tests/cache/test_shelve.py
@@ -21,5 +21,5 @@ class ShelveCacheTestCase(unittest.TestCase):
         self.assertEqual(self.cache.get('foo'), 'bar')
 
     def test_expire(self):
-        self.cache.put('baz', 'qux', 0)
+        self.cache.put('baz', 'qux', -1)
         self.assertEqual(self.cache.get('baz'), None)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ class CacheTestCase(unittest.TestCase):
         self.assertEqual(self.cache.get('foo'), 'bar')
 
     def test_expire(self):
-        self.cache.put('baz', 'qux', 0)
+        self.cache.put('baz', 'qux', -1)
         self.assertEqual(self.cache.get('baz'), None)
 
 class APITestCase(unittest.TestCase):


### PR DESCRIPTION
Set cache time in unit test from 0 to -1 to account for windows timestamp granularity
