### PR TITLE
Barebone coveragerc file.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+omit =
+    */python?.?/*
+    */lib-python/?.?/*.py
+    */lib_pypy/*.py
+    */site-packages/*
+
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover


### PR DESCRIPTION
For coverage testing, if the coverage package is available.  I typically run with

``` sh
$ nosetests --cover-erase --with-coverage
```
