### PR TITLE
Add contactTypeID to ContactList Parser

### DIFF
--- a/evelink/parsing/contact_list.py
+++ b/evelink/parsing/contact_list.py
@@ -16,7 +16,7 @@ def parse_contact_list(api_result):
             contact_id = int(row.get('contactID'))
             contact_list[contact_id] = {
                 'id': contact_id,
-                'typeid': int(row.get('contactTypeID')),
+                'type_id': int(row.get('contactTypeID')),
                 'name': row.get('contactName'),
                 'standing': float(row.get('standing')),
                 'in_watchlist': in_watchlist


### PR DESCRIPTION
The EVE API exposes contactTypeID - this should be exposed in the parsed output.
