### PR TITLE
Adding support for custom user agents

### DIFF
--- a/evelink/__init__.py
+++ b/evelink/__init__.py
@@ -23,8 +23,7 @@ _log = logging.getLogger('evelink')
 _log.addHandler(NullHandler())
 
 # Update the version number used in the user-agent
-_user_agent = 'evelink v%s' % __version__
-api._user_agent = _user_agent
+api._user_agent = 'evelink v%s' % __version__
 
 __all__ = [
   "account",

--- a/evelink/api.py
+++ b/evelink/api.py
@@ -11,8 +11,6 @@ from urllib import urlencode
 import urllib2
 from xml.etree import ElementTree
 
-from evelink import constants
-
 _log = logging.getLogger('evelink.api')
 
 _user_agent = None

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,6 @@ import unittest2 as unittest
 import mock
 import urllib2
 
-from evelink import _user_agent
 import evelink.api as evelink_api
 
 def compress(s):
@@ -130,7 +129,7 @@ class APITestCase(unittest.TestCase):
         self.cache.get.return_value = None
 
         self.api.get('foo/Bar', {'a':[1,2,3]})
-        test_useragent = '%s %s' % (_user_agent, self.custom_useragent)
+        test_useragent = '%s %s' % (evelink_api._user_agent, self.custom_useragent)
 
         self.assertEquals(mock_urlopen.call_args[0][0].headers['User-agent'], test_useragent)
 

--- a/tests/test_requests_api.py
+++ b/tests/test_requests_api.py
@@ -5,8 +5,6 @@ import mock
 
 import evelink.api as evelink_api
 
-from evelink import _user_agent
-
 class DummyResponse(object):
     def __init__(self, content):
         self.content = content
@@ -119,7 +117,7 @@ class RequestsAPITestCase(unittest.TestCase):
 
         self.api.get('foo', {'a':[2,3,4]})
 
-        test_useragent = '%s %s' % (_user_agent, self.custom_useragent)
+        test_useragent = '%s %s' % (evelink_api._user_agent, self.custom_useragent)
 
         self.assertEquals(self.mock_sessions.headers.update.call_args[0][0]['User-Agent'], test_useragent)
 


### PR DESCRIPTION
Added support for custom header on both urllib2 and requests, default user agent can be found in the consts but can also be appended when instantiating the API class.
