### PR TITLE
Put doc files in appropriate linux doc dir when available.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ from evelink import __version__
 
 __readme_path = os.path.join(os.path.dirname(__file__), "README.md")
 __readme_contents = open(__readme_path).read()
+__docdir=""
+
+if os.path.exists("/usr/share/doc"):
+    __docdir="/usr/share/doc/evelink-" + __version__
 
 setup(
     name="EVELink",
@@ -28,7 +32,7 @@ setup(
         "evelink.thirdparty",
     ],
     data_files=[
-        ('', ['README.md', 'LICENSE']),
+        (__docdir, ['README.md', 'LICENSE']),
     ],
     scripts=["bin/evelink"],
     provides=["evelink"],


### PR DESCRIPTION
Currently, I have to patch the setup.py when I make a package for my Linux distro in order to place the doc files in the appropriate dir.
