### PR TITLE
replacing hash() with sha1 from hash lib

### DIFF
--- a/evelink/api.py
+++ b/evelink/api.py
@@ -222,7 +222,7 @@ class API(object):
     def _cache_key(self, path, params):
         sorted_params = sorted(params.items())
         # Paradoxically, Shelve doesn't like integer keys.
-        return '%s-%s' % (self.CACHE_VERSION, hashlib.md5(str([path,sorted_params]).encode("utf-8")).hexdigest())
+        return '%s-%s' % (self.CACHE_VERSION, hashlib.sha1(str([path,sorted_params]).encode("utf-8")).hexdigest())
 
     def get(self, path, params=None):
         """Request a specific path from the EVE API.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -98,7 +98,7 @@ class APITestCase(unittest.TestCase):
 
     def test_cache_key_value(self):        
         self.assertEqual(
-            "%s-ad63beb1981558158a5d40adfa80aca7" % self.api.CACHE_VERSION,
+            "%s-56cdb36bbb5ad30d7d50556509d657d05eae0250" % self.api.CACHE_VERSION,
             self.api._cache_key('foo/bar', {'a':1})
         )
 


### PR DESCRIPTION
this fixes eve-val/evelink#168, tested with python 2 and python 3.

hashlib md5 is a bit picky what it takes.. I tried bytes and strings but looks like this is the easiest thing that works with py2 and py3
