### PR TITLE
Only urlencode params when using urllib.

### DIFF
--- a/evelink/api.py
+++ b/evelink/api.py
@@ -247,7 +247,6 @@ class API(object):
 
         if not cached:
             # no cached response body found, call the API for one.
-            params = urllib.parse.urlencode(params)
             full_path = "https://%s/%s.xml.aspx" % (self.base_url, path)
             response = self.send_request(full_path, params)
         else:
@@ -286,6 +285,7 @@ class API(object):
             if params:
                 # POST request
                 _log.debug("POSTing request")
+                params = urllib.parse.urlencode(params)
                 req = urllib.request.Request(full_path, data=params.encode())
             else:
                 # GET request

--- a/tests/test_requests_api.py
+++ b/tests/test_requests_api.py
@@ -107,10 +107,10 @@ class RequestsAPITestCase(unittest.TestCase):
         # Make sure the api key id and verification code were passed
         call_args, call_kwargs = self.mock_sessions.post.mock_calls[0][1:3]
         called_url = call_args[0]
-        called_param_dict = parse_qs(call_kwargs["data"])
+        called_param_dict = call_kwargs["data"]
 
         expected_url = 'https://api.eveonline.com/foo.xml.aspx'
-        expected_param_dict = parse_qs('a=2%2C3%2C4&vCode=code&keyID=1')
+        expected_param_dict = {'a': '2,3,4', 'vCode': 'code', 'keyID': 1}
 
         self.assertEqual(called_url, expected_url)
         self.assertEqual(called_param_dict, expected_param_dict)


### PR DESCRIPTION
The `requests` library expects a dict rather than
a urlencoded string for its 'data' parameter, and
behaves poorly when it receives a string instead.
