### PR TITLE
Adding support for the corporation name from the employment history

### DIFF
--- a/evelink/eve.py
+++ b/evelink/eve.py
@@ -237,9 +237,11 @@ class EVE(object):
         history = api_result.result.find('rowset')
         for row in history.findall('row'):
             corp_id = int(row.attrib['corporationID'])
+            corp_name = row.attrib['corporationName']
             start_date = api.parse_ts(row.attrib['startDate'])
             results['history'].append({
                     'corp_id': corp_id,
+                    'corp_name': corp_name,
                     'start_ts': start_date,
                 })
 

--- a/tests/test_eve.py
+++ b/tests/test_eve.py
@@ -176,8 +176,8 @@ class EVETestCase(APITestCase):
             'bloodline': 'Civire',
             'corp': {'id': 2345, 'name': 'Test Corporation', 'timestamp': 1338689400},
             'history': [
-                {'corp_id': 1, 'start_ts': 1338603000},
-                {'corp_id': 2, 'start_ts': 1318422896}
+                {'corp_id': 1, 'corp_name': 'test_one', 'start_ts': 1338603000},
+                {'corp_id': 2, 'corp_name': 'test_two', 'start_ts': 1318422896}
             ],
             'id': 1234,
             'isk': None,

--- a/tests/xml/eve/character_info.xml
+++ b/tests/xml/eve/character_info.xml
@@ -8,7 +8,7 @@
     <corporationDate>2012-06-03 02:10:00</corporationDate>
     <securityStatus>2.50000000000000</securityStatus>
     <rowset name="employmentHistory">
-        <row corporationID="1" startDate="2012-06-02 02:10:00" />
-        <row corporationID="2" startDate="2011-10-12 12:34:56" />
+        <row corporationID="1" corporationName="test_one" startDate="2012-06-02 02:10:00" />
+        <row corporationID="2" corporationName="test_two" startDate="2011-10-12 12:34:56" />
     </rowset>
 </result>


### PR DESCRIPTION
Adding support for the corporation name from the employment history of t...he CharacterInfo endpoint. This change is on Singularity now and will hit Tranquility on August 26th.

You may not want to actually pull this until the changes are on TQ, but I had a few minutes to spare now so figured I would toss this pull request together. :)

An example of this on Sisi can be found here: http://api.testeveonline.com/eve/CharacterInfo.xml.aspx?characterID=92168909
