### PR TITLE
fix unittest deprecation warnings under python 3.4

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,7 +141,7 @@ class APITestCase(unittest.TestCase):
         self.api.get('foo/Bar', {'a':[1,2,3]})
         test_useragent = '%s %s' % (evelink_api._user_agent, self.custom_useragent)
 
-        self.assertEquals(mock_urlopen.call_args[0][0].headers['User-agent'], test_useragent)
+        self.assertEqual(mock_urlopen.call_args[0][0].headers['User-agent'], test_useragent)
 
     @mock.patch('evelink.thirdparty.six.moves.urllib.request.urlopen')
     def test_cached_get(self, mock_urlopen):

--- a/tests/test_requests_api.py
+++ b/tests/test_requests_api.py
@@ -137,7 +137,7 @@ class RequestsAPITestCase(unittest.TestCase):
 
         test_useragent = '%s %s' % (evelink_api._user_agent, self.custom_useragent)
 
-        self.assertEquals(self.mock_sessions.headers.update.call_args[0][0]['User-Agent'], test_useragent)
+        self.assertEqual(self.mock_sessions.headers.update.call_args[0][0]['User-Agent'], test_useragent)
 
     def test_get_with_error(self):
         self.mock_sessions.get.return_value = DummyResponse(self.error_xml)


### PR DESCRIPTION
I got deprecation warnings when running `python3 -m unittest discover`. The tests appear to pass with both python3 and python2.
