### PR TITLE
fix obvious issues in evelink script

### DIFF
--- a/bin/evelink
+++ b/bin/evelink
@@ -3,10 +3,7 @@
 
 from __future__ import print_function
 
-try:
-  from configparser import RawConfigParser
-except:
-  from ConfigParser import RawConfigParser
+from six.moves.configparser import RawConfigParser
 import json
 import logging
 import optparse


### PR DESCRIPTION
These issues had to be fixed just to get the script to run under python3.4:
- print is a function in python3 (PEP 3105)
- ConfigParser became configparser
