### PR TITLE
allow newer version of requests

### DIFF
--- a/requirements_py2.txt
+++ b/requirements_py2.txt
@@ -5,4 +5,4 @@ nose==1.1.2
 unittest2==0.5.1
 wsgiref==0.1.2
 NoseGAE==0.2.0
-requests>=2.4.3
+requests>=2.0.0

--- a/requirements_py3.txt
+++ b/requirements_py3.txt
@@ -2,4 +2,4 @@ argparse>=1.1
 setuptools>=0.7
 mock==1.0b1
 nose==1.1.2
-requests>=2.4.3
+requests>=2.0.0


### PR DESCRIPTION
It appears that the requests library had some python3 compatibility issues that
were fixed between version 1.1.0 and the current version.

This fixes the following error when I actually try to make a request from the API using python3:

```
$ evelink eve.EVE.character_id_from_name "Stewart Cash"
APIResult(result=1759081950, timestamp=1413306683, expires=1415985083)
[stesla@WUD-STESLA03:~/Projects/evelink (master=)]$ rm ~/.evelink_cache 
[stesla@WUD-STESLA03:~/Projects/evelink (master=)]$ evelink eve.EVE.character_id_from_name "Stewart Cash"
Traceback (most recent call last):
  File "/home/stesla/Projects/evelink/bin/evelink", line 108, in call_evelink_api
    result = method_obj(*args, **kwargs)
  File "/home/stesla/Projects/evelink/evelink/eve.py", line 139, in character_id_from_name
    api_result = self.character_ids_from_names([name])
  File "/home/stesla/Projects/evelink/evelink/api.py", line 503, in wrapper
    kw['api_result'] = client.api.get(self.path, params=params)
  File "/home/stesla/Projects/evelink/evelink/api.py", line 258, in get
    response, robj = self.send_request(full_path, params)
  File "/home/stesla/Projects/evelink/evelink/api.py", line 308, in send_request
    return self.requests_request(full_path, params)
  File "/home/stesla/Projects/evelink/evelink/api.py", line 356, in requests_request
    r = session.post(full_path, data=params)
  File "/home/stesla/local/python-3.4.1/lib/python3.4/site-packages/requests/sessions.py", line 340, in post
    return self.request('POST', url, data=data, **kwargs)
  File "/home/stesla/local/python-3.4.1/lib/python3.4/site-packages/requests/sessions.py", line 279, in request
    resp = self.send(prep, stream=stream, timeout=timeout, verify=verify, cert=cert, proxies=proxies)
  File "/home/stesla/local/python-3.4.1/lib/python3.4/site-packages/requests/sessions.py", line 374, in send
    r = adapter.send(request, **kwargs)
  File "/home/stesla/local/python-3.4.1/lib/python3.4/site-packages/requests/adapters.py", line 174, in send
    timeout=timeout
  File "/home/stesla/local/python-3.4.1/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 417, in urlopen
    conn = self._get_conn(timeout=pool_timeout)
  File "/home/stesla/local/python-3.4.1/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 232, in _get_conn
    return conn or self._new_conn()
  File "/home/stesla/local/python-3.4.1/lib/python3.4/site-packages/requests/packages/urllib3/connectionpool.py", line 547, in _new_conn
    strict=self.strict)
TypeError: __init__() got an unexpected keyword argument 'strict'
```

Pleasantly, this seems to wrap up the fixes to get the `evelink` script working under python3. I've been able to poke at several API end points with it successfully now.
