### PR TITLE
Fix for #201

### DIFF
--- a/evelink/char.py
+++ b/evelink/char.py
@@ -206,10 +206,6 @@ class Char(object):
                 'id': _int('allianceID') or None,
                 'name': _str('allianceName'),
             },
-            'clone': {
-                'name': _str('cloneName'),
-                'skillpoints': _int('cloneSkillPoints'),
-            },
             'balance': _float('balance'),
             'attributes': {},
             'implants': {},

--- a/tests/test_char.py
+++ b/tests/test_char.py
@@ -256,10 +256,6 @@ class CharTestCase(APITestCase):
                 'id': None,
                 'name': None
             },
-            'clone': {
-                'name': 'Clone Grade Pi',
-                'skillpoints': 54600000,
-            },
             'balance': 190210393.87,
             'attributes': {
                 'charisma': {'base': 7},

--- a/tests/xml/char/character_sheet.xml
+++ b/tests/xml/char/character_sheet.xml
@@ -10,8 +10,6 @@
   <corporationID>150337746</corporationID>
   <allianceName />
   <allianceID>0</allianceID>
-  <cloneName>Clone Grade Pi</cloneName>
-  <cloneSkillPoints>54600000</cloneSkillPoints>
   <balance>190210393.87</balance>
   <jumpActivation>2014-10-28 17:33:41</jumpActivation>
   <jumpFatigue>2014-10-28 17:33:35</jumpFatigue>


### PR DESCRIPTION
Removed cloneName and cloneSkillPoints from evelink.char.character_sheet and the relevant tests.

I defiantly wouldn't pull this until Rhea ships. Not sure how you want to handle it after that. The API will still return static values, however useless, for a month or so. You can pull right away or give people a bit more time before pulling. :)
