### PR TITLE
Use the short cache endpoint for kills()

### DIFF
--- a/evelink/char.py
+++ b/evelink/char.py
@@ -137,9 +137,22 @@ class Char(object):
         """Get a list of PI routing entries for a character's planet."""
         return api.APIResult(parse_planetary_routes(api_result.result), api_result.timestamp, api_result.expires)
 
-    @auto_call('char/KillLog', map_params={'before_kill': 'beforeKillID'})
+    @auto_call('char/KillMails', map_params={'before_kill': 'beforeKillID'})
     def kills(self, before_kill=None, api_result=None):
         """Look up recent kills for a character.
+
+        before_kill:
+            Optional. Only show kills before this kill id. (Used for paging.)
+        """
+
+        return api.APIResult(parse_kills(api_result.result), api_result.timestamp, api_result.expires)
+
+    @auto_call('char/KillLog', map_params={'before_kill': 'beforeKillID'})
+    def kill_log(self, before_kill=None, api_result=None):
+        """Look up recent kills for a character.
+
+        Note: this method uses the long cache version of the endpoint. If you
+              want to use the short cache version (recommended), use kills().
 
         before_kill:
             Optional. Only show kills before this kill id. (Used for paging.)

--- a/evelink/corp.py
+++ b/evelink/corp.py
@@ -136,9 +136,22 @@ class Corp(object):
 
         return api.APIResult(results, api_result.timestamp, api_result.expires)
 
-    @api.auto_call('corp/KillLog', map_params={'before_kill': 'beforeKillID'})
+    @api.auto_call('corp/KillMails', map_params={'before_kill': 'beforeKillID'})
     def kills(self, before_kill=None, api_result=None):
         """Look up recent kills for a corporation.
+
+        before_kill:
+            Optional. Only show kills before this kill id. (Used for paging.)
+        """
+
+        return api.APIResult(parse_kills(api_result.result), api_result.timestamp, api_result.expires)
+
+    @api.auto_call('corp/KillLog', map_params={'before_kill': 'beforeKillID'})
+    def kill_log(self, before_kill=None, api_result=None):
+        """Look up recent kills for a corporation.
+
+        Note: this method uses the long cache version of the endpoint. If you
+              want to use the short cache version (recommended), use kills().
 
         before_kill:
             Optional. Only show kills before this kill id. (Used for paging.)

--- a/tests/test_char.py
+++ b/tests/test_char.py
@@ -293,6 +293,23 @@ class CharTestCase(APITestCase):
 
         self.assertEqual(result, mock.sentinel.kills)
         self.assertEqual(self.api.mock_calls, [
+                mock.call.get('char/KillMails', params={'characterID': 1}),
+            ])
+        self.assertEqual(mock_parse.mock_calls, [
+                mock.call(mock.sentinel.api_result),
+            ])
+
+    @mock.patch('evelink.char.parse_kills')
+    def test_kill_log(self, mock_parse):
+        self.api.get.return_value = API_RESULT_SENTINEL
+        mock_parse.return_value = mock.sentinel.kills
+
+        result, current, expires = self.char.kill_log()
+        self.assertEqual(current, 12345)
+        self.assertEqual(expires, 67890)
+
+        self.assertEqual(result, mock.sentinel.kills)
+        self.assertEqual(self.api.mock_calls, [
                 mock.call.get('char/KillLog', params={'characterID': 1}),
             ])
         self.assertEqual(mock_parse.mock_calls, [
@@ -304,7 +321,7 @@ class CharTestCase(APITestCase):
 
         self.char.kills(before_kill=12345)
         self.assertEqual(self.api.mock_calls, [
-                mock.call.get('char/KillLog', params={'characterID': 1, 'beforeKillID': 12345}),
+                mock.call.get('char/KillMails', params={'characterID': 1, 'beforeKillID': 12345}),
             ])
 
     def test_character_sheet(self):

--- a/tests/test_corp.py
+++ b/tests/test_corp.py
@@ -167,6 +167,23 @@ class CorpTestCase(APITestCase):
 
         self.assertEqual(result, mock.sentinel.kills)
         self.assertEqual(self.api.mock_calls, [
+                mock.call.get('corp/KillMails', params={}),
+            ])
+        self.assertEqual(mock_parse.mock_calls, [
+                mock.call(mock.sentinel.api_result),
+            ])
+        self.assertEqual(current, 12345)
+        self.assertEqual(expires, 67890)
+
+    @mock.patch('evelink.corp.parse_kills')
+    def test_kill_log(self, mock_parse):
+        self.api.get.return_value = API_RESULT_SENTINEL
+        mock_parse.return_value = mock.sentinel.kills
+
+        result, current, expires = self.corp.kill_log()
+
+        self.assertEqual(result, mock.sentinel.kills)
+        self.assertEqual(self.api.mock_calls, [
                 mock.call.get('corp/KillLog', params={}),
             ])
         self.assertEqual(mock_parse.mock_calls, [


### PR DESCRIPTION
The old endpoint is now available at kill_log() if desired.

Fixes #210. Resolves #211.