### PR TITLE
Make the 'skills' value be a dict.

### DIFF
--- a/evelink/char.py
+++ b/evelink/char.py
@@ -316,17 +316,18 @@ class Char(object):
             }
 
 
-        result['skills'] = []
+        result['skills'] = {}
         result['skillpoints'] = 0
         for skill in rowsets['skills']:
             a = skill.attrib
+            skill_id = int(a['typeID'])
             sp = int(a['skillpoints'])
-            result['skills'].append({
-                'id': int(a['typeID']),
+            result['skills'][skill_id] = {
+                'id': skill_id,
                 'skillpoints': sp,
                 'level': int(a['level']),
                 'published': a['published'] == '1',
-            })
+            }
             result['skillpoints'] += sp
 
         result['roles'] = {}

--- a/tests/test_char.py
+++ b/tests/test_char.py
@@ -362,13 +362,13 @@ class CharTestCase(APITestCase):
                 33527: 'High-grade Ascendancy Epsilon',
                 33528: 'High-grade Ascendancy Gamma',
             },
-            'skills': [
-                {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3431},
-                {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3413},
-                {'level': 1, 'published': True, 'skillpoints': 500, 'id': 21059},
-                {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3416},
-                {'level': 5, 'published': False, 'skillpoints': 512000, 'id': 3445}
-            ],
+            'skills': {
+                3431: {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3431},
+                3413: {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3413},
+                21059: {'level': 1, 'published': True, 'skillpoints': 500, 'id': 21059},
+                3416: {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3416},
+                3445: {'level': 5, 'published': False, 'skillpoints': 512000, 'id': 3445}
+            },
             'skillpoints': 536500,
             'roles': {
                 'global': {1 : {'id': 1, 'name': 'roleDirector'}},


### PR DESCRIPTION
Given that skills have unique IDs, it makes sense to have them be sorted
into a dictionary for easy lookup by ID. Legacy code can be changed to
call the .values()/.itervalues() methods if it still wants to iterate.

Resolves #209.