### PR TITLE
Citadel patch updates

### DIFF
--- a/tests/test_char.py
+++ b/tests/test_char.py
@@ -364,6 +364,105 @@ class CharTestCase(APITestCase):
                 mock.call.get('char/KillMails', params={'characterID': 1, 'beforeKillID': 12345}),
             ])
 
+    def test_clones(self):
+        self.api.get.return_value = self.make_api_result("char/clones.xml")
+
+        result, current, expires = self.char.clones()
+        self.assertEqual(current, 12345)
+        self.assertEqual(expires, 67890)
+
+        self.assertEqual(result, {
+            'create_ts': 1136073600,
+            'race': 'Minmatar',
+            'bloodline': 'Brutor',
+            'ancestry': 'Slave Child',
+            'gender': 'Female',
+            'attributes': {
+                'charisma': {'base': 7},
+                'intelligence': {'base': 6},
+                'memory': {'base': 4},
+                'perception': {'base': 12},
+                'willpower': {'base': 10},
+            },
+            'implants': {
+                33516: 'High-grade Ascendancy Alpha',
+                33525: 'High-grade Ascendancy Beta',
+                33526: 'High-grade Ascendancy Delta',
+                33527: 'High-grade Ascendancy Epsilon',
+                33528: 'High-grade Ascendancy Gamma',
+            },
+            'remote_station_ts': 1414507856,
+            'last_respec_ts': 1402496116,
+            'last_timed_respec_ts': 1399734757,
+            'free_respecs': 2,
+            'jumpclone': {
+                'clones': {
+                    60014842: {
+                        'id': 5,
+                        'location_id': 60014842,
+                        'name': '',
+                        'type_id': 164,
+                        'implants': {
+                            22119: 'Mid-grade Slave Alpha',
+                            22120: 'Mid-grade Slave Beta',
+                            22121: 'Mid-grade Slave Delta',
+                            22122: 'Mid-grade Slave Epsilon',
+                            22123: 'Mid-grade Slave Gamma',
+                            22124: 'Mid-grade Slave Omega',
+                        },
+                    },
+                    60014848: {
+                        'id': 4,
+                        'location_id': 60014848,
+                        'name': 'some random name',
+                        'type_id': 164,
+                        'implants': {
+                            20499: 'High-grade Slave Alpha',
+                            20501: 'High-grade Slave Beta',
+                            20503: 'High-grade Slave Delta',
+                            20505: 'High-grade Slave Epsilon',
+                            20507: 'High-grade Slave Gamma',
+                            20509: 'High-grade Slave Omega',
+                            33068: 'QA SpaceAnchor Implant',
+                        },
+                    },
+                    60014930: {
+                        'id': 2,
+                        'location_id': 60014930,
+                        'name': '',
+                        'type_id': 164,
+                        'implants': {},
+                    },
+                },
+                'jump_ts': 1412801690,
+            },
+        })
+        self.assertEqual(self.api.mock_calls, [
+                mock.call.get('char/Clones', params={'characterID': 1}),
+            ])
+
+    def test_skills(self):
+        self.api.get.return_value = self.make_api_result("char/skills.xml")
+
+        result, current, expires = self.char.skills()
+        self.assertEqual(current, 12345)
+        self.assertEqual(expires, 67890)
+
+        self.assertEqual(result, {
+            'skills': {
+                3431: {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3431},
+                3413: {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3413},
+                21059: {'level': 1, 'published': True, 'skillpoints': 500, 'id': 21059},
+                3416: {'level': 3, 'published': True, 'skillpoints': 8000, 'id': 3416},
+                3445: {'level': 5, 'published': False, 'skillpoints': 512000, 'id': 3445}
+            },
+            'skillpoints': 536500,
+            'free_skillpoints': 50000,
+        })
+        self.assertEqual(self.api.mock_calls, [
+                mock.call.get('char/Skills', params={'characterID': 1}),
+            ])
+
     def test_character_sheet(self):
         self.api.get.return_value = self.make_api_result("char/character_sheet.xml")
 

--- a/tests/xml/char/clones.xml
+++ b/tests/xml/char/clones.xml
@@ -1,0 +1,47 @@
+<result>
+  <DoB>2006-01-01 00:00:00</DoB>
+  <race>Minmatar</race>
+  <bloodLine>Brutor</bloodLine>
+  <ancestry>Slave Child</ancestry>
+  <gender>Female</gender>
+  <remoteStationDate>2014-10-28 14:50:56</remoteStationDate>
+  <lastRespecDate>2014-06-11 14:15:16</lastRespecDate>
+  <lastTimedRespec>2014-05-10 15:12:37</lastTimedRespec>
+  <freeRespecs>2</freeRespecs>
+  <homeStationID>60011566</homeStationID>
+  <cloneJumpDate>2014-10-08 20:54:50</cloneJumpDate>
+  <attributes>
+    <intelligence>6</intelligence>
+    <memory>4</memory>
+    <charisma>7</charisma>
+    <perception>12</perception>
+    <willpower>10</willpower>
+  </attributes>
+  <rowset name="jumpClones" key="jumpCloneID" columns="jumpCloneID,typeID,locationID,cloneName">
+    <row jumpCloneID="2" typeID="164" locationID="60014930" cloneName="" />
+    <row jumpCloneID="4" typeID="164" locationID="60014848" cloneName="some random name" />
+    <row jumpCloneID="5" typeID="164" locationID="60014842" cloneName="" />
+  </rowset>
+  <rowset name="jumpCloneImplants" key="jumpCloneID" columns="jumpCloneID,typeID,typeName">
+    <row jumpCloneID="4" typeID="20499" typeName="High-grade Slave Alpha" />
+    <row jumpCloneID="4" typeID="20501" typeName="High-grade Slave Beta" />
+    <row jumpCloneID="4" typeID="20503" typeName="High-grade Slave Delta" />
+    <row jumpCloneID="4" typeID="20505" typeName="High-grade Slave Epsilon" />
+    <row jumpCloneID="4" typeID="20507" typeName="High-grade Slave Gamma" />
+    <row jumpCloneID="4" typeID="20509" typeName="High-grade Slave Omega" />
+    <row jumpCloneID="4" typeID="33068" typeName="QA SpaceAnchor Implant" />
+    <row jumpCloneID="5" typeID="22119" typeName="Mid-grade Slave Alpha" />
+    <row jumpCloneID="5" typeID="22120" typeName="Mid-grade Slave Beta" />
+    <row jumpCloneID="5" typeID="22121" typeName="Mid-grade Slave Delta" />
+    <row jumpCloneID="5" typeID="22122" typeName="Mid-grade Slave Epsilon" />
+    <row jumpCloneID="5" typeID="22123" typeName="Mid-grade Slave Gamma" />
+    <row jumpCloneID="5" typeID="22124" typeName="Mid-grade Slave Omega" />
+  </rowset>
+  <rowset name="implants" key="typeID" columns="typeID,typeName">
+    <row typeID="33516" typeName="High-grade Ascendancy Alpha" />
+    <row typeID="33525" typeName="High-grade Ascendancy Beta" />
+    <row typeID="33528" typeName="High-grade Ascendancy Gamma" />
+    <row typeID="33526" typeName="High-grade Ascendancy Delta" />
+    <row typeID="33527" typeName="High-grade Ascendancy Epsilon" />
+  </rowset>
+</result>

--- a/tests/xml/char/skills.xml
+++ b/tests/xml/char/skills.xml
@@ -1,0 +1,10 @@
+<result>
+  <freeSkillPoints>50000</freeSkillPoints>
+  <rowset name="skills" key="typeID" columns="typeID,skillpoints,level,published">
+    <row typeID="3431" skillpoints="8000" level="3" published="1"/>
+    <row typeID="3413" skillpoints="8000" level="3" published="1"/>
+    <row typeID="21059" skillpoints="500" level="1" published="1"/>
+    <row typeID="3416" skillpoints="8000" level="3" published="1"/>
+    <row typeID="3445" skillpoints="512000" level="5" published="0"/>
+  </rowset>
+</result>


### PR DESCRIPTION
**Add support for SSO token authentication**
Use this support by passing the sso_token
parameter of an API object a tuple with the
access token and the access type in that
order. (Omitting the type is not supported.)

**Add support for char/Clones and char/Skills**
These endpoints are strict subsets of the
character sheet fields for this data.