### PR TITLE
add contract_id parameter to contracts()

### DIFF
--- a/evelink/char.py
+++ b/evelink/char.py
@@ -83,8 +83,8 @@ class Char(object):
         """Lists items that a specified contract contains"""
         return api.APIResult(parse_contract_items(api_result.result), api_result.timestamp, api_result.expires)
 
-    @auto_call('char/Contracts')
-    def contracts(self, api_result=None):
+    @auto_call('char/Contracts', map_params={'contract_id' : 'contractID'})
+    def contracts(self, contract_id = None, api_result=None):
         """Returns a record of all contracts for a specified character"""
         return api.APIResult(parse_contracts(api_result.result), api_result.timestamp, api_result.expires)
 

--- a/evelink/corp.py
+++ b/evelink/corp.py
@@ -262,8 +262,8 @@ class Corp(object):
         """Lists items that a specified contract contains"""
         return api.APIResult(parse_contract_items(api_result.result), api_result.timestamp, api_result.expires)
 
-    @api.auto_call('corp/Contracts')
-    def contracts(self, api_result=None):
+    @api.auto_call('corp/Contracts', map_params={'contract_id' : 'contractID'})
+    def contracts(self, contract_id = None, api_result=None):
         """Get information about corp contracts."""
         return api.APIResult(parse_contracts(api_result.result), api_result.timestamp, api_result.expires)
 

--- a/tests/test_char.py
+++ b/tests/test_char.py
@@ -96,6 +96,22 @@ class CharTestCase(APITestCase):
         self.assertEqual(current, 12345)
         self.assertEqual(expires, 67890)
 
+    @mock.patch('evelink.char.parse_contracts')
+    def test_contracts_specific(self, mock_parse):
+        self.api.get.return_value = API_RESULT_SENTINEL
+        mock_parse.return_value = mock.sentinel.parsed_contracts
+
+        result, current, expires = self.char.contracts(contract_id=23)
+        self.assertEqual(result, mock.sentinel.parsed_contracts)
+        self.assertEqual(mock_parse.mock_calls, [
+                mock.call(mock.sentinel.api_result),
+            ])
+        self.assertEqual(self.api.mock_calls, [
+                mock.call.get('char/Contracts', params={'characterID': 1, 'contractID' : 23,}),
+            ])
+        self.assertEqual(current, 12345)
+        self.assertEqual(expires, 67890)
+
     @mock.patch('evelink.char.parse_wallet_journal')
     def test_wallet_journal(self, mock_parse):
         self.api.get.return_value = API_RESULT_SENTINEL

--- a/tests/test_corp.py
+++ b/tests/test_corp.py
@@ -240,6 +240,22 @@ class CorpTestCase(APITestCase):
         self.assertEqual(current, 12345)
         self.assertEqual(expires, 67890)
 
+    @mock.patch('evelink.corp.parse_contracts')
+    def test_contracts_specific(self, mock_parse):
+        self.api.get.return_value = API_RESULT_SENTINEL
+        mock_parse.return_value = mock.sentinel.parsed_contracts
+
+        result, current, expires = self.corp.contracts(contract_id=2468)
+        self.assertEqual(result, mock.sentinel.parsed_contracts)
+        self.assertEqual(mock_parse.mock_calls, [
+                mock.call(mock.sentinel.api_result),
+            ])
+        self.assertEqual(self.api.mock_calls, [
+                mock.call.get('corp/Contracts', params={'contractID' : 2468}),
+            ])
+        self.assertEqual(current, 12345)
+        self.assertEqual(expires, 67890)
+        
     @mock.patch('evelink.corp.parse_contact_list')
     def test_contacts(self, mock_parse):
         self.api.get.return_value = API_RESULT_SENTINEL


### PR DESCRIPTION
Allows individual contracts to be retrieved via the corp or char objects.

This change implements an optional parameter which is mentioned in the documentation: http://eveonline-third-party-documentation.readthedocs.io/en/latest/xmlapi/character/char_contracts.html