### PR TITLE
Remove Python 3.2 from CI; add 3.4 and 3.5

### DIFF
--- a/.travis-pre-run.py
+++ b/.travis-pre-run.py
@@ -13,9 +13,10 @@ from xml.etree import ElementTree as ET
 from zipfile import ZipFile
 
 
+# TODO: this feed no longer exists; figure out where (if anywhere) to grab url
 GAE_FEED_URL = 'https://code.google.com/feeds/p/googleappengine/downloads/basic'
 SDK_PATTERN = r'http://googleappengine.googlecode.com/files/google_appengine_(\d\.)+zip'
-DEFAULT_URL = 'http://googleappengine.googlecode.com/files/google_appengine_1.8.9.zip'
+DEFAULT_URL = 'https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.40.zip'
 
 _log = logging.getLogger('travis.prerun')
 logging.basicConfig(level=logging.INFO)

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
+  - "3.4"
+  - "3.5"
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install -r requirements_py2.txt --use-mirrors; fi
   - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install -r requirements_py2.txt --use-mirrors; fi


### PR DESCRIPTION
Python 3.2 is no longer used by much of anyone,
and as a result libraries like requests are no
longer supporting it.