### PR TITLE
Remove gae-application line from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
 [nosetests]
 
 where=tests/
-gae-application=tests/


### PR DESCRIPTION
Its value is identical to the default value, and its presence breaks nosetests invocation when NoseGAE isn't installed (e.g. Python 3)

Fixes #234.