### PR TITLE
Adds `flat` flag to corp and char Assets API call

### DIFF
--- a/evelink/char.py
+++ b/evelink/char.py
@@ -42,8 +42,8 @@ class Char(object):
         self.api = api
         self.char_id = char_id
 
-    @auto_call('char/AssetList')
-    def assets(self, api_result=None):
+    @auto_call('char/AssetList', map_params={'flat': 'flat'})
+    def assets(self, api_result=None, flat=None):
         """Get information about corp assets.
 
         Each item is a dict, with keys 'id', 'item_type_id',

--- a/evelink/corp.py
+++ b/evelink/corp.py
@@ -190,8 +190,8 @@ class Corp(object):
         """Return a corporation's buy and sell orders."""
         return api.APIResult(parse_market_orders(api_result.result), api_result.timestamp, api_result.expires)
 
-    @api.auto_call('corp/AssetList')
-    def assets(self, api_result=None):
+    @api.auto_call('corp/AssetList', map_params={'flat': 'flat'})
+    def assets(self, api_result=None, flat=None):
         """Get information about corp assets.
 
         Each item is a dict, with keys 'id', 'item_type_id',


### PR DESCRIPTION
The `flat` flag is the only way to retrieve assets within citadels at this time. More information about the flag can be found [here](http://eveonline-third-party-documentation.readthedocs.io/en/latest/xmlapi/character/char_assetlist.html).